### PR TITLE
Fix class not found exception from binary conf

### DIFF
--- a/geomesa-bigtable/geomesa-bigtable-tools/conf/hbase-site.xml
+++ b/geomesa-bigtable/geomesa-bigtable-tools/conf/hbase-site.xml
@@ -1,7 +1,7 @@
 <configuration>
   <property>
     <name>hbase.client.connection.impl</name>
-    <value>com.google.cloud.bigtable.hbase1_2.BigtableConnection</value>
+    <value>com.google.cloud.bigtable.hbase1_3.BigtableConnection</value>
   </property>
   <property>
     <name>google.bigtable.instance.id</name>


### PR DESCRIPTION
The provided `hbase-site.xml` is looking for `com.google.cloud.bigtable.hbase1_2`, however, the `pom.xml` grabs `1.3`. 

Without this change:

```
ERROR Could not get distributed version:
java.util.concurrent.CompletionException: java.io.IOException: java.lang.ClassNotFoundException: com.google.cloud.bigtable.hbase1_2.BigtableConnection
        at com.github.benmanes.caffeine.cache.UnboundedLocalCache$UnboundedLocalLoadingCache.lambda$new$0(UnboundedLocalCache.java:929)
        at com.github.benmanes.caffeine.cache.UnboundedLocalCache.lambda$computeIfAbsent$2(UnboundedLocalCache.java:235)
        at java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1660)
        at com.github.benmanes.caffeine.cache.UnboundedLocalCache.computeIfAbsent(UnboundedLocalCache.java:231)
        at com.github.benmanes.caffeine.cache.LocalCache.computeIfAbsent(LocalCache.java:113)
        at com.github.benmanes.caffeine.cache.LocalLoadingCache.get(LocalLoadingCache.java:65)
...
```